### PR TITLE
Use `Kernel.#system` to run browserify command

### DIFF
--- a/lib/brwy_rails/runner.rb
+++ b/lib/brwy_rails/runner.rb
@@ -37,7 +37,7 @@ module BrwyRails
 
     def run_with_browserify(target)
       ensure_output_dir!
-      exec browserify_cmd(target), chdir: Rails.root
+      system browserify_cmd(target), chdir: Rails.root
     end
 
     def browserify_cmd(target)


### PR DESCRIPTION
## WHY

bwry_rails runs browserify command before `assets:precompile`
task. Since `Kernel.#exec` replaces the current process by running the given external
command, `rake assets:precompile` task stops after browserify command is
executed. Then bwry_rails has to use `Kernel.#system` instead of
`Kernel.#exec`. `Kernel.#system` doesn't replace the current process.
## REF
- [`Kernel.#exec` - Ruby Doc ](http://ruby-doc.org/core-2.2.3/Kernel.html#method-i-exec)
- [`Kernel.#system` - Ruby Doc](http://ruby-doc.org/core-2.2.3/Kernel.html#method-i-system)
